### PR TITLE
EVG-14486: use archlinux-new distros in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -147,7 +147,7 @@ buildvariants:
       GO_BIN_PATH: /opt/golang/go1.9/bin/go
       GOROOT: /opt/golang/go1.9
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks: [ "testGroup" ]
 
   - name: lint
@@ -156,7 +156,7 @@ buildvariants:
       GO_BIN_PATH: /opt/golang/go1.13/bin/go
       GOROOT: /opt/golang/go1.13
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks: [ "lintGroup" ]
 
   - name: ubuntu1604


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14486