### PR TITLE
EVG-14482, EVG-14502: upgrade go version and linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -143,9 +143,9 @@ buildvariants:
     expansions:
       RACE_DETECTOR: true
       DISABLE_COVERAGE: true
-      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.4.tgz
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      GOROOT: /opt/golang/go1.9
+      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
     tasks: [ "testGroup" ]
@@ -153,29 +153,29 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
     tasks: [ "lintGroup" ]
 
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu
+    display_name: Ubuntu 18.04
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      GOROOT: /opt/golang/go1.9
-      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-3.6.4.tgz
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
+      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
     run_on:
-      - ubuntu1604-test
+      - ubuntu1804-small
     tasks: [ "testGroup" ]
 
   - name: macos
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: yes
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      GOROOT: /opt/golang/go1.9
-      MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-osx-x86_64-3.2.9.tgz
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
+      MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:
       - macos-1014
     tasks: [ "testGroup" ]

--- a/makefile
+++ b/makefile
@@ -26,6 +26,7 @@ endif
 export GOCACHE := $(gocache)
 export GOPATH := $(gopath)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.

--- a/makefile
+++ b/makefile
@@ -48,7 +48,7 @@ testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*
 # lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
-	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets


### PR DESCRIPTION
* Upgrade go version to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade MongoDB to 4.0.
* Upgrade Ubuntu to 18.04.