### PR TITLE
EVG-15094: add support for hinted queries

### DIFF
--- a/db/interface.go
+++ b/db/interface.go
@@ -46,6 +46,9 @@ type Query interface {
 	Select(interface{}) Query
 	Skip(n int) Query
 	Sort(...string) Query
+	// Hint tells the query which index to use. The input must be either the
+	// name of the index as a string or the index specification as a document.
+	Hint(interface{}) Query
 	Apply(Change, interface{}) (*ChangeInfo, error)
 	Results
 }

--- a/db/wrapper.go
+++ b/db/wrapper.go
@@ -405,12 +405,14 @@ type queryWrapper struct {
 	limit      int
 	skip       int
 	sort       []string
+	hint       interface{}
 }
 
 func (q *queryWrapper) Limit(l int) Query             { q.limit = l; return q }
 func (q *queryWrapper) Select(proj interface{}) Query { q.projection = proj; return q }
 func (q *queryWrapper) Sort(keys ...string) Query     { q.sort = append(q.sort, keys...); return q }
 func (q *queryWrapper) Skip(s int) Query              { q.skip = s; return q }
+func (q *queryWrapper) Hint(h interface{}) Query      { q.hint = h; return q }
 func (q *queryWrapper) Count() (int, error) {
 	v, err := q.coll.CountDocuments(q.ctx, q.filter)
 	return int(v), errors.WithStack(err)
@@ -494,6 +496,9 @@ func (q *queryWrapper) exec() error {
 	}
 	if q.skip > 0 {
 		opts.SetSkip(int64(q.skip))
+	}
+	if q.hint != "" {
+		opts.SetHint(q.hint)
 	}
 
 	var err error

--- a/db/wrapper_legacy.go
+++ b/db/wrapper_legacy.go
@@ -78,6 +78,10 @@ func (q queryLegacyWrapper) Limit(n int) Query          { return queryLegacyWrap
 func (q queryLegacyWrapper) Skip(n int) Query           { return queryLegacyWrapper{q.Query.Skip(n)} }
 func (q queryLegacyWrapper) Select(p interface{}) Query { return queryLegacyWrapper{q.Query.Select(p)} }
 
+// Hint is an unsupported no-op because the legacy driver's support for hints is
+// limited.
+func (q queryLegacyWrapper) Hint(h interface{}) Query { return queryLegacyWrapper{q.Query} }
+
 func (q queryLegacyWrapper) Apply(ch Change, result interface{}) (*ChangeInfo, error) {
 	i, err := q.Query.Apply(buildChange(ch), result)
 	return buildChangeInfo(i), errors.WithStack(err)

--- a/mock/db.go
+++ b/mock/db.go
@@ -180,6 +180,7 @@ type Query struct {
 	SortKeys        []string
 	NumLimit        int
 	NumSkip         int
+	IndexHint       interface{}
 	Error           error
 	CountNum        int
 	ApplyChangeSpec db.Change
@@ -190,6 +191,7 @@ func (q *Query) Count() (int, error)           { return q.CountNum, q.Error }
 func (q *Query) Limit(n int) db.Query          { q.NumLimit = n; return q }
 func (q *Query) Select(p interface{}) db.Query { q.Project = p; return q }
 func (q *Query) Skip(n int) db.Query           { q.NumSkip = n; return q }
+func (q *Query) Hint(h interface{}) db.Query   { q.IndexHint = h; return q }
 func (q *Query) Iter() db.Iterator             { return &Iterator{Error: q.Error, Query: q} }
 func (q *Query) One(r interface{}) error       { return q.Error }
 func (q *Query) All(r interface{}) error       { return q.Error }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15094

Allow find queries in the new mongo driver to take hints as either the index name or a BSON document of the ordered keys for the index. Some caveats:

* This doesn't work for aggregations because the aggregation interface doesn'tt allow you to pass options. There's a ticket ([EVG-15177](https://jira.mongodb.org/browse/EVG-15177)) to support aggregations with options.
* This only works for the new mongo driver and not the legacy Go driver, because the legacy Go driver has a hack-ish support for hints. Anyways, it's probably irrelevant since we don't use the legacy Go driver client anymore.