### PR TITLE
EVG-14028 add maxTime

### DIFF
--- a/db/interface.go
+++ b/db/interface.go
@@ -9,7 +9,6 @@ type Session interface {
 	Copy() Session
 	Close()
 	DB(string) Database
-	SetSocketTimeout(time.Duration)
 	Error() error
 }
 
@@ -24,7 +23,7 @@ type Database interface {
 // mgo.Collection type.
 type Collection interface {
 	DropCollection() error
-	Pipe(interface{}) Results
+	Pipe(interface{}) Aggregation
 	Find(interface{}) Query
 	FindId(interface{}) Query
 	Count() (int, error)
@@ -50,6 +49,13 @@ type Query interface {
 	// name of the index as a string or the index specification as a document.
 	Hint(interface{}) Query
 	Apply(Change, interface{}) (*ChangeInfo, error)
+	MaxTime(time.Duration) Query
+	Results
+}
+
+type Aggregation interface {
+	Hint(interface{}) Aggregation
+	MaxTime(time.Duration) Aggregation
 	Results
 }
 
@@ -79,8 +85,7 @@ type Iterator interface {
 }
 
 // Results reflect the output of a database operation and is part of
-// the query interface, and is returned by the pipeline (e.g
-// aggregation operation.)
+// the query interface
 type Results interface {
 	All(interface{}) error
 	One(interface{}) error

--- a/db/wrapper.go
+++ b/db/wrapper.go
@@ -16,12 +16,10 @@ import (
 // WrapClient provides the anser database Session interface, which is
 // modeled on mgo's interface but based on new mongo.Client fundamentals.
 func WrapClient(ctx context.Context, client *mongo.Client) Session {
-	maxTime := time.Duration(0)
 	return &sessionWrapper{
 		ctx:     ctx,
 		client:  client,
 		catcher: grip.NewCatcher(),
-		maxTime: &maxTime,
 	}
 }
 
@@ -30,7 +28,6 @@ type sessionWrapper struct {
 	canceler context.CancelFunc
 	client   *mongo.Client
 	catcher  grip.Catcher
-	maxTime  *time.Duration
 	isClone  bool
 }
 
@@ -38,14 +35,13 @@ func (s *sessionWrapper) Clone() Session { s.isClone = true; return s }
 func (s *sessionWrapper) Copy() Session  { s.isClone = true; return s }
 func (s *sessionWrapper) Error() error   { return s.catcher.Resolve() }
 func (s *sessionWrapper) SetSocketTimeout(d time.Duration) {
-	*s.maxTime = d
+	s.ctx, s.canceler = context.WithTimeout(s.ctx, d)
 }
 
 func (s *sessionWrapper) DB(name string) Database {
 	return &databaseWrapper{
 		ctx:      s.ctx,
 		database: s.client.Database(name),
-		maxTime:  s.maxTime,
 	}
 }
 
@@ -63,33 +59,26 @@ func (s *sessionWrapper) Close() {
 type databaseWrapper struct {
 	ctx      context.Context
 	database *mongo.Database
-	maxTime  *time.Duration
 }
 
 func (d *databaseWrapper) Name() string        { return d.database.Name() }
 func (d *databaseWrapper) DropDatabase() error { return errors.WithStack(d.database.Drop(d.ctx)) }
 func (d *databaseWrapper) C(coll string) Collection {
 	return &collectionWrapper{
-		ctx:     d.ctx,
-		coll:    d.database.Collection(coll),
-		maxTime: d.maxTime,
+		ctx:  d.ctx,
+		coll: d.database.Collection(coll),
 	}
 }
 
 type collectionWrapper struct {
-	ctx     context.Context
-	coll    *mongo.Collection
-	maxTime *time.Duration
+	ctx  context.Context
+	coll *mongo.Collection
 }
 
 func (c *collectionWrapper) DropCollection() error { return errors.WithStack(c.coll.Drop(c.ctx)) }
 
 func (c *collectionWrapper) Pipe(p interface{}) Results {
-	opts := options.Aggregate().SetAllowDiskUse(true)
-	if c.maxTime != nil && *c.maxTime > 0 {
-		opts.SetMaxTime(*c.maxTime)
-	}
-	cursor, err := c.coll.Aggregate(c.ctx, p, opts)
+	cursor, err := c.coll.Aggregate(c.ctx, p, options.Aggregate().SetAllowDiskUse(true))
 
 	return &resultsWrapper{
 		err:    err,
@@ -100,19 +89,17 @@ func (c *collectionWrapper) Pipe(p interface{}) Results {
 
 func (c *collectionWrapper) Find(q interface{}) Query {
 	return &queryWrapper{
-		ctx:     c.ctx,
-		coll:    c.coll,
-		filter:  q,
-		maxTime: c.maxTime,
+		ctx:    c.ctx,
+		coll:   c.coll,
+		filter: q,
 	}
 }
 
 func (c *collectionWrapper) FindId(id interface{}) Query {
 	return &queryWrapper{
-		ctx:     c.ctx,
-		coll:    c.coll,
-		filter:  bson.D{{Key: "_id", Value: id}},
-		maxTime: c.maxTime,
+		ctx:    c.ctx,
+		coll:   c.coll,
+		filter: bson.D{{Key: "_id", Value: id}},
 	}
 }
 
@@ -419,7 +406,6 @@ type queryWrapper struct {
 	skip       int
 	sort       []string
 	hint       interface{}
-	maxTime    *time.Duration
 }
 
 func (q *queryWrapper) Limit(l int) Query             { q.limit = l; return q }
@@ -513,9 +499,6 @@ func (q *queryWrapper) exec() error {
 	}
 	if q.hint != "" {
 		opts.SetHint(q.hint)
-	}
-	if q.maxTime != nil && *q.maxTime > 0 {
-		opts.SetMaxTime(*q.maxTime)
 	}
 
 	var err error

--- a/db/wrapper.go
+++ b/db/wrapper.go
@@ -449,7 +449,8 @@ func (q *queryWrapper) exec() error {
 		q.filter = struct{}{}
 	}
 
-	opts := options.Find()
+	opts := options.Find().SetHint(q.hint)
+
 	if q.projection != nil {
 		opts.SetProjection(q.projection)
 	}
@@ -461,9 +462,6 @@ func (q *queryWrapper) exec() error {
 	}
 	if q.skip > 0 {
 		opts.SetSkip(int64(q.skip))
-	}
-	if q.hint != "" {
-		opts.SetHint(q.hint)
 	}
 	if q.maxTime > 0 {
 		opts.SetMaxTime(q.maxTime)
@@ -528,10 +526,10 @@ func (a *aggregationWrapper) exec() error {
 		return nil
 	}
 
-	opts := options.Aggregate().SetAllowDiskUse(true)
-	if a.hint != "" {
-		opts.SetHint(a.hint)
-	}
+	opts := options.Aggregate().
+		SetAllowDiskUse(true).
+		SetHint(a.hint)
+
 	if a.maxTime > 0 {
 		opts.SetMaxTime(a.maxTime)
 	}

--- a/db/wrapper.go
+++ b/db/wrapper.go
@@ -34,9 +34,6 @@ type sessionWrapper struct {
 func (s *sessionWrapper) Clone() Session { s.isClone = true; return s }
 func (s *sessionWrapper) Copy() Session  { s.isClone = true; return s }
 func (s *sessionWrapper) Error() error   { return s.catcher.Resolve() }
-func (s *sessionWrapper) SetSocketTimeout(d time.Duration) {
-	s.ctx, s.canceler = context.WithTimeout(s.ctx, d)
-}
 
 func (s *sessionWrapper) DB(name string) Database {
 	return &databaseWrapper{
@@ -77,13 +74,11 @@ type collectionWrapper struct {
 
 func (c *collectionWrapper) DropCollection() error { return errors.WithStack(c.coll.Drop(c.ctx)) }
 
-func (c *collectionWrapper) Pipe(p interface{}) Results {
-	cursor, err := c.coll.Aggregate(c.ctx, p, options.Aggregate().SetAllowDiskUse(true))
-
-	return &resultsWrapper{
-		err:    err,
-		cursor: cursor,
-		ctx:    c.ctx,
+func (c *collectionWrapper) Pipe(p interface{}) Aggregation {
+	return &aggregationWrapper{
+		ctx:      c.ctx,
+		coll:     c.coll,
+		pipeline: p,
 	}
 }
 
@@ -337,38 +332,6 @@ func (b *bulkWrapper) Run() (*BulkResult, error) {
 	return &BulkResult{Matched: int(res.MatchedCount), Modified: int(res.ModifiedCount)}, nil
 }
 
-type resultsWrapper struct {
-	ctx    context.Context
-	cursor *mongo.Cursor
-	err    error
-}
-
-func (r *resultsWrapper) All(result interface{}) error {
-	if r.err != nil {
-		return errors.WithStack(r.err)
-	}
-
-	return errors.WithStack(r.cursor.All(r.ctx, result))
-}
-
-func (r *resultsWrapper) One(result interface{}) error {
-	if r.err != nil {
-		return errors.WithStack(r.err)
-	}
-
-	return errors.WithStack(ResolveCursorOne(r.ctx, r.cursor, result))
-}
-
-func (r *resultsWrapper) Iter() Iterator {
-	catcher := grip.NewCatcher()
-	catcher.Add(r.err)
-	return &iteratorWrapper{
-		ctx:     r.ctx,
-		cursor:  r.cursor,
-		catcher: catcher,
-	}
-}
-
 type iteratorWrapper struct {
 	ctx        context.Context
 	cursor     *mongo.Cursor
@@ -406,6 +369,7 @@ type queryWrapper struct {
 	skip       int
 	sort       []string
 	hint       interface{}
+	maxTime    time.Duration
 }
 
 func (q *queryWrapper) Limit(l int) Query             { q.limit = l; return q }
@@ -413,6 +377,7 @@ func (q *queryWrapper) Select(proj interface{}) Query { q.projection = proj; ret
 func (q *queryWrapper) Sort(keys ...string) Query     { q.sort = append(q.sort, keys...); return q }
 func (q *queryWrapper) Skip(s int) Query              { q.skip = s; return q }
 func (q *queryWrapper) Hint(h interface{}) Query      { q.hint = h; return q }
+func (q *queryWrapper) MaxTime(d time.Duration) Query { q.maxTime = d; return q }
 func (q *queryWrapper) Count() (int, error) {
 	v, err := q.coll.CountDocuments(q.ctx, q.filter)
 	return int(v), errors.WithStack(err)
@@ -500,6 +465,9 @@ func (q *queryWrapper) exec() error {
 	if q.hint != "" {
 		opts.SetHint(q.hint)
 	}
+	if q.maxTime > 0 {
+		opts.SetMaxTime(q.maxTime)
+	}
 
 	var err error
 
@@ -539,6 +507,63 @@ func (q *queryWrapper) Iter() Iterator {
 	return &iteratorWrapper{
 		ctx:     q.ctx,
 		cursor:  q.cursor,
+		catcher: catcher,
+	}
+}
+
+type aggregationWrapper struct {
+	ctx      context.Context
+	coll     *mongo.Collection
+	pipeline interface{}
+	cursor   *mongo.Cursor
+	hint     interface{}
+	maxTime  time.Duration
+}
+
+func (a *aggregationWrapper) Hint(hint interface{}) Aggregation   { a.hint = hint; return a }
+func (a *aggregationWrapper) MaxTime(d time.Duration) Aggregation { a.maxTime = d; return a }
+
+func (a *aggregationWrapper) exec() error {
+	if a.cursor != nil {
+		return nil
+	}
+
+	opts := options.Aggregate().SetAllowDiskUse(true)
+	if a.hint != "" {
+		opts.SetHint(a.hint)
+	}
+	if a.maxTime > 0 {
+		opts.SetMaxTime(a.maxTime)
+	}
+
+	var err error
+	a.cursor, err = a.coll.Aggregate(a.ctx, a.pipeline, opts)
+
+	return errors.WithStack(err)
+}
+
+func (a *aggregationWrapper) All(result interface{}) error {
+	if err := a.exec(); err != nil {
+		return errors.WithStack(err)
+	}
+	return errors.WithStack(a.cursor.All(a.ctx, result))
+}
+
+func (a *aggregationWrapper) One(result interface{}) error {
+	if err := a.exec(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return errors.WithStack(ResolveCursorOne(a.ctx, a.cursor, result))
+}
+
+func (a *aggregationWrapper) Iter() Iterator {
+	catcher := grip.NewCatcher()
+	catcher.Add(a.exec())
+
+	return &iteratorWrapper{
+		ctx:     a.ctx,
+		cursor:  a.cursor,
 		catcher: catcher,
 	}
 }


### PR DESCRIPTION
[EVG-14028](https://jira.mongodb.org/browse/EVG-14028)

I think the problem with the drop-in replacement for `SetSocketTimeout` is that setting the sessionWrapper's context doesn't propagate down to queries made with a databaseWrapper already derived from the session. For example, [here](https://github.com/evergreen-ci/evergreen/blob/c0bd08d96d5a9c43fc11df494a48a18acdf6870f/model/task_history.go#L260) we get the DB from the session that captures the ctx from the session. The session wrapper's _new_ context from `SetSocketTimeout` won't get passed to queries made from the db.
Also, Divjot warned against killing the context we pass to the driver as part of the application's regular functioning.

My conclusion was to use max time, as Brian had originally suggested in [the ticket](https://jira.mongodb.org/browse/EVG-14028). I made it a pointer so it would be shared with the DB/Query wrappers.