### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -32,7 +32,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/anser/
       binary: make
       args: ["${make_args|}", "${target}"]
-      add_expansions_to_env: true
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
       env:
         GOPATH: ${workdir}/gopath
         VENDOR_PKG: "github.com/${trigger_repo_owner}/${trigger_repo_name}"
@@ -41,7 +41,7 @@ functions:
     - command: subprocess.exec
       type: setup
       params:
-        add_expansions_to_env: true
+        include_expansions_in_env: ["MONGODB_URL"]
         env:
           DECOMPRESS: ${decompress}
         working_dir: gopath/src/github.com/mongodb/anser/
@@ -49,20 +49,20 @@ functions:
     - command: subprocess.exec
       type: setup
       params:
+        include_expansions_in_env: ["MONGODB_URL"]
         background: true
         working_dir: gopath/src/github.com/mongodb/anser/
-        add_expansions_to_env: true
         command: make start-mongod
     - command: subprocess.exec
       type: setup
       params:
+        include_expansions_in_env: ["MONGODB_URL"]
         working_dir: gopath/src/github.com/mongodb/anser/
-        add_expansions_to_env: true
         command: make check-mongod
     - command: subprocess.exec
       type: setup
       params:
-        add_expansions_to_env: true
+        include_expansions_in_env: ["MONGODB_URL"]
         working_dir: gopath/src/github.com/mongodb/anser/
         command: make init-rs
 
@@ -144,7 +144,6 @@ buildvariants:
       RACE_DETECTOR: true
       DISABLE_COVERAGE: true
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
@@ -153,7 +152,6 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
@@ -162,7 +160,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.3.tgz
     run_on:
@@ -173,7 +170,6 @@ buildvariants:
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: yes
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.3.tgz
     run_on:

--- a/makefile
+++ b/makefile
@@ -4,114 +4,70 @@ buildDir := build
 packages := $(name) mock model db bsonutil client apm backup
 orgPath := github.com/mongodb
 projectPath := $(orgPath)/$(name)
+testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 # end project configuration
 
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq (,$(gobin))
-	gobin := go
+gobin := go
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
 
-gocache := $(abspath $(buildDir)/.cache)
-gopath := $(GOPATH)
-goroot := $(goroot)
-ifeq (,$(gopath))
-gopath := $(shell $(gobin) env GOPATH)
-endif
 ifeq ($(OS),Windows_NT)
-gocache := $(shell cygpath -m $(gocache))
-gopath := $(shell cygpath -m $(gopath))
-goroot := $(shell cygpath -m $(goroot))
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
-export GOCACHE := $(gocache)
-export GOPATH := $(gopath)
-export GOROOT := $(goroot)
+
 export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies.
-#   this block has no project specific configuration but defines
-#   variables that project specific information depends on
-testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
-raceOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).race)
-testBin := $(foreach target,$(packages),$(buildDir)/test.$(target))
-raceBin := $(foreach target,$(packages),$(buildDir)/race.$(target))
-lintTargets := $(foreach target,$(packages),lint-$(target))
-coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
-# end dependency installation tools
+.DEFAULT_GOAL := compile
 
-# lint setup targets
+# start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets
 
+# start output files
+testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
+lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
+coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+# end output files
 
-# userfacing targets for basic build and development operations
-compile $(buildDir):
+# start basic development targets
+compile:
 	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach pkg,$(packages),./$(pkg))))
-test:$(testOutput)
-coverage:$(coverageOutput)
-coverage-html:$(coverageHtmlOutput)
-lint:$(lintTargets)
-list-tests:
-	@echo -e "test targets:" $(foreach target,$(packages),\\n\\ttest-$(target))
-phony := lint build test coverage coverage-html
-.PRECIOUS:$(testOutput) $(raceOutput) $(coverageOutput) $(coverageHtmlOutput)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/test.$(target))
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-# end front-ends
+test: $(testOutput)
+lint: $(lintOutput)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony := compile lint test coverage coverage-html
 
-
-# convenience targets for runing tests and coverage tasks on a
+# start convenience targets for running tests and coverage tasks on a
 # specific package.
-race-%:$(buildDir)/output.%.race
-	@grep -s -q -e "^PASS" $< && ! grep -s -q "^WARNING: DATA RACE" $<
-test-%:$(buildDir)/output.%.test
+test-%: $(buildDir)/output.%.test
 	@grep -s -q -e "^PASS" $<
-coverage-%:$(buildDir)/output.%.coverage
+coverage-%: $(buildDir)/output.%.coverage
 	@grep -s -q -e "^PASS" $(subst coverage,test,$<)
-html-coverage-%:$(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
+html-coverage-%: $(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
 	@grep -s -q -e "^PASS" $(subst coverage,test,$<)
-lint-%:$(buildDir)/output.%.lint
+lint-%: $(buildDir)/output.%.lint
 	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
-
-
-# start vendoring configuration
-vendor-clean:
-	rm -rf vendor/github.com/mongodb/amboy/vendor/github.com/mongodb/grip/
-	rm -rf vendor/github.com/mongodb/amboy/vendor/github.com/stretchr/testify/
-	rm -rf vendor/github.com/mongodb/amboy/vendor/go.mongodb.org/mongo-driver/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/evergreen-ci/birch/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/mongodb/grip/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/pkg/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/stretchr/testify/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/go.mongodb.org/mongo-driver/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/gopkg.in/mgo.v2/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/gopkg.in/mgo.v2/
-	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
-	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/satori/go.uuid/
-	rm -rf vendor/gopkg.in/mgo.v2/harness/
-	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -rf
-	find vendor/ -name '.git' | xargs rm -rf
-#   add phony targets
-phony += vendor-clean
-# end vendoring tooling configuration
-
+# end convenience targets
+# end basic development targets
 
 # start test and coverage artifacts
-#    This varable includes everything that the tests actually need to
-#    run. (The "build" target is intentional and makes these targetsb
-#    rerun as expected.)
 testArgs := -v -timeout=10m
 ifneq (,$(RUN_TEST))
 testArgs += -run='$(RUN_TEST)'
@@ -128,21 +84,43 @@ endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif
-# testing targets
 $(buildDir)/output.%.test: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 $(buildDir)/output.%.coverage: .FORCE
 	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
 	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
 	$(gobin) tool cover -html=$< -o $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter .FORCE
-	@$(if $(GO_BIN_PATH),PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --packages='$*'
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --packages='$*'
 # end test and coverage artifacts
 
-# mongodb utility targets
+# start vendoring configuration
+vendor-clean:
+	rm -rf vendor/github.com/mongodb/amboy/vendor/github.com/mongodb/grip/
+	rm -rf vendor/github.com/mongodb/amboy/vendor/github.com/stretchr/testify/
+	rm -rf vendor/github.com/mongodb/amboy/vendor/go.mongodb.org/mongo-driver/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/evergreen-ci/birch/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/mongodb/grip/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/pkg/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/stretchr/testify/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/go.mongodb.org/mongo-driver/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/gopkg.in/mgo.v2/
+	rm -rf vendor/github.com/mongodb/ftdc/vendor/github.com/satori/go.uuid/
+	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
+	rm -rf vendor/gopkg.in/mgo.v2/harness/
+	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -rf
+	find vendor/ -name '.git' | xargs rm -rf
+phony += vendor-clean
+# end vendoring configuration
+
+# start mongodb targets
 mongodb/.get-mongodb:
 	rm -rf mongodb
 	mkdir -p mongodb
@@ -158,17 +136,17 @@ init-rs: mongodb/.get-mongodb
 check-mongod: mongodb/.get-mongodb
 	./mongodb/mongo --nodb --eval "assert.soon(function(x){try{var d = new Mongo(\"localhost:27017\"); return true}catch(e){return false}}, \"timed out connecting\")"
 	@echo "mongod is up"
+phony += get-mongodb start-mongod init-rs check-mongod
 # end mongodb targets
 
-
-# clean and other utility targets
+# start cleanup targets
 clean:
-	rm -rf $(lintDeps)
+	rm -rf $(buildDir)
 clean-results:
 	rm -rf $(buildDir)/output.*
-phony += clean
-# end dependency targets
+phony += clean clean-results
+# end cleanup targets
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony) .FORCE
+.PHONY: $(phony) .FORCE


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.