### PR TITLE
EVG-16402: add method to create collection

### DIFF
--- a/db/interface.go
+++ b/db/interface.go
@@ -16,6 +16,7 @@ type Session interface {
 type Database interface {
 	Name() string
 	C(string) Collection
+	CreateCollection(coll string) (Collection, error)
 	DropDatabase() error
 }
 

--- a/db/wrapper.go
+++ b/db/wrapper.go
@@ -58,8 +58,21 @@ type databaseWrapper struct {
 	database *mongo.Database
 }
 
-func (d *databaseWrapper) Name() string        { return d.database.Name() }
+func (d *databaseWrapper) Name() string { return d.database.Name() }
+
 func (d *databaseWrapper) DropDatabase() error { return errors.WithStack(d.database.Drop(d.ctx)) }
+
+func (d *databaseWrapper) CreateCollection(coll string) (Collection, error) {
+	if err := d.database.CreateCollection(d.ctx, coll); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &collectionWrapper{
+		ctx:  d.ctx,
+		coll: d.database.Collection(coll),
+	}, nil
+}
+
 func (d *databaseWrapper) C(coll string) Collection {
 	return &collectionWrapper{
 		ctx:  d.ctx,

--- a/mock/db_legacy.go
+++ b/mock/db_legacy.go
@@ -81,6 +81,19 @@ func (d *LegacyDatabase) C(n string) db.Collection {
 	return d.Collections[n]
 }
 
+func (d *LegacyDatabase) CreateCollection(coll string) (db.Collection, error) {
+	d.Mutex.Lock()
+	defer d.Mutex.Unlock()
+
+	if _, ok := d.Collections[coll]; ok {
+		return nil, errors.New("collection already exists")
+	}
+
+	d.Collections[coll] = &LegacyCollection{}
+
+	return d.Collections[coll], nil
+}
+
 func (d *LegacyDatabase) DropDatabase() error {
 	return nil
 }


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-16402

Add method to create a collection. This is primarily useful for tests where documents are inserted via transactions, since transactions require the collection to exist before the transaction can occur.