### PR TITLE
EVG-15746: Don't use ftdc anymore.

### DIFF
--- a/apm/wrappers.go
+++ b/apm/wrappers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/mongodb/ftdc"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/recovery"
 )
@@ -36,38 +35,6 @@ func (m *loggingMonitor) flusher(ctx context.Context) {
 			return
 		case <-ticker.C:
 			grip.Info(m.Monitor.Rotate().Message())
-		}
-	}
-}
-
-type ftdcCollector struct {
-	collector ftdc.Collector
-	interval  time.Duration
-	Monitor
-}
-
-// NewFTDCMonitor produces a monitor implementation that automatically
-// flushes the event data to an FTDC data collector.
-func NewFTDCMonitor(ctx context.Context, dur time.Duration, collector ftdc.Collector, m Monitor) Monitor {
-	impl := &ftdcCollector{
-		interval:  dur,
-		collector: collector,
-		Monitor:   m,
-	}
-	go impl.flusher(ctx)
-	return impl
-}
-
-func (m *ftdcCollector) flusher(ctx context.Context) {
-	defer recovery.LogStackTraceAndContinue("timeseries driver apm collector")
-	ticker := time.NewTicker(m.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			grip.Warning(m.collector.Add(m.Monitor.Rotate().Document()))
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826
 	github.com/mongodb/amboy v0.0.0-20220408143015-94858bb64f00
-	github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809
 	github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -309,7 +309,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/mongodb/amboy v0.0.0-20220408143015-94858bb64f00 h1:IcY4k5HI+AzP9pBmN4dIpP+q58Y360DQjbxGSqZe7kE=
 github.com/mongodb/amboy v0.0.0-20220408143015-94858bb64f00/go.mod h1:pyAwlkip3M7Hw91UqQpTo9Oo7clNgGFdOqa9EvgvhbM=
 github.com/mongodb/ftdc v0.0.0-20211018154918-80dd1c22e4cf/go.mod h1:qd800FxWJIh4VUqu2d9Cmzdpv1CGXMqdwkntAKbaLlY=
-github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809 h1:CQVEigRr2M/OFIPn+wQWerSadMioMY1cLp22yZX+Ygk=
 github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809/go.mod h1:zz0HHFUU4/TOxl9TW4P9t3y3Ivx+sTWS2nwnhuYYRdw=
 github.com/mongodb/grip v0.0.0-20211018154934-e661a71929d5/go.mod h1:g0r93iHSTLD50bDT7vNj+z+Y3nKz9o/tQXtB9esq2tk=
 github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21 h1:SBXhTs+Umg5AX4uBrNbfq6hbxJELFCN42j3fC7QJG+M=


### PR DESCRIPTION
We weren't using the ftdc monitor, and it was having issues with data races, so we go ahead and remove the code here.