### PR TITLE
EVG-19190 make ErrNotFound public

### DIFF
--- a/db/errors.go
+++ b/db/errors.go
@@ -5,8 +5,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-var errNotFound = errors.New("document not found")
+var ErrNotFound = errors.New("document not found")
 
 func ResultsNotFound(err error) bool {
-	return errors.Cause(err) == errNotFound || errors.Cause(err) == mongo.ErrNoDocuments
+	return errors.Cause(err) == ErrNotFound || errors.Cause(err) == mongo.ErrNoDocuments
 }

--- a/db/errors_test.go
+++ b/db/errors_test.go
@@ -15,5 +15,5 @@ func TestResultsPredicate(t *testing.T) {
 	assert.False(ResultsNotFound(nil))
 	assert.False(ResultsNotFound(errors.New("not found")))
 	assert.True(ResultsNotFound(mongo.ErrNoDocuments))
-	assert.True(ResultsNotFound(errNotFound))
+	assert.True(ResultsNotFound(ErrNotFound))
 }

--- a/db/wrapper.go
+++ b/db/wrapper.go
@@ -205,7 +205,7 @@ func (c *collectionWrapper) Update(q interface{}, u interface{}) error {
 	}
 
 	if res.MatchedCount == 0 {
-		return errors.WithStack(errNotFound)
+		return errors.WithStack(ErrNotFound)
 	}
 
 	return nil
@@ -230,7 +230,7 @@ func (c *collectionWrapper) UpdateId(q interface{}, u interface{}) error {
 	}
 
 	if res.MatchedCount == 0 {
-		return errors.WithStack(errNotFound)
+		return errors.WithStack(ErrNotFound)
 	}
 
 	return nil
@@ -592,7 +592,7 @@ func ResolveCursorOne(ctx context.Context, iter *mongo.Cursor, result interface{
 	}()
 
 	if !iter.Next(ctx) {
-		return errors.WithStack(errNotFound)
+		return errors.WithStack(ErrNotFound)
 	}
 
 	catcher.Add(iter.Decode(result))


### PR DESCRIPTION
[EVG-19190](https://jira.mongodb.org/browse/EVG-19190)

I needed to use `ErrNotFound` in evergreen because returning it will keep the behavior of UpdateOne consistent with the wrapper.