### PR TITLE
DEVPROD-12355 add response bytes attribute

### DIFF
--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -32,7 +32,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const defaultTracerName = "go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
+const (
+	defaultTracerName        = "go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
+	response_bytes_attribute = "db.response_bytes"
+)
 
 // config is used to configure the mongo tracer.
 type config struct {
@@ -156,14 +159,24 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 }
 
 func (m *monitor) Succeeded(ctx context.Context, evt *event.CommandSucceededEvent) {
-	m.Finished(&evt.CommandFinishedEvent, nil)
+	span, ok := m.getSpan(&evt.CommandFinishedEvent)
+	if !ok {
+		return
+	}
+	span.SetAttributes(attribute.Int(response_bytes_attribute, len(evt.Reply)))
+	span.End()
 }
 
 func (m *monitor) Failed(ctx context.Context, evt *event.CommandFailedEvent) {
-	m.Finished(&evt.CommandFinishedEvent, fmt.Errorf("%s", evt.Failure))
+	span, ok := m.getSpan(&evt.CommandFinishedEvent)
+	if !ok {
+		return
+	}
+	span.SetStatus(codes.Error, evt.Failure)
+	span.End()
 }
 
-func (m *monitor) Finished(evt *event.CommandFinishedEvent, err error) {
+func (m *monitor) getSpan(evt *event.CommandFinishedEvent) (trace.Span, bool) {
 	key := spanKey{
 		ConnectionID: evt.ConnectionID,
 		RequestID:    evt.RequestID,
@@ -174,15 +187,8 @@ func (m *monitor) Finished(evt *event.CommandFinishedEvent, err error) {
 		delete(m.spans, key)
 	}
 	m.Unlock()
-	if !ok {
-		return
-	}
 
-	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-	}
-
-	span.End()
+	return span, ok
 }
 
 // TODO sanitize values where possible, then reenable `db.statement` span attributes default.

--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	defaultTracerName        = "go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
-	response_bytes_attribute = "db.response_bytes"
+	defaultTracerName      = "go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo"
+	responseBytesAttribute = "db.response_bytes"
 )
 
 // config is used to configure the mongo tracer.


### PR DESCRIPTION
[DEVPROD-12355](https://jira.mongodb.org/browse/DEVPROD-12355)

This adds an attribute to the db instrumentation with the size of the data being transferred from the db to the apps. This would have been useful when we were trying to understand what was saturating the dbs' network link and is generally interesting (who would have thought starting up the apps pulls [7MB from the dbs](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/abcp242wcNH) just for the admin settings 🤨).