### PR TITLE
DEVPROD-12355 fix to #95

### DIFF
--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -163,7 +163,7 @@ func (m *monitor) Succeeded(ctx context.Context, evt *event.CommandSucceededEven
 	if !ok {
 		return
 	}
-	span.SetAttributes(attribute.Int(response_bytes_attribute, len(evt.Reply)))
+	span.SetAttributes(attribute.Int(responseBytesAttribute, len(evt.Reply)))
 	span.End()
 }
 


### PR DESCRIPTION
[DEVPROD-12355](https://jira.mongodb.org/browse/DEVPROD-12355)

#95 introduced a bug because I was not thinking when I made a quick change and merged. This rectifies the mistake.