### PR TITLE
DEVPROD-12678 reduce query span attribute to its shape

### DIFF
--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -314,13 +314,15 @@ func extractAggregation(statement bson.Raw) (bson.Raw, error) {
 		return nil, errors.Wrap(err, "getting elements for aggregation statement")
 	}
 
+	var pipelineDoc bson.D
 	for _, elem := range elems {
 		if elem.Key() == "pipeline" {
-			return elem.Value().Value, nil
+			pipelineDoc = bson.D{bson.E{Key: elem.Key(), Value: elem.Value()}}
+			break
 		}
 	}
 
-	return nil, nil
+	return bson.Marshal(pipelineDoc)
 }
 
 func extractDelete(statement bson.Raw) (bson.Raw, error) {

--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -303,6 +303,8 @@ func operationSection(commandName string, raw bson.Raw) (bson.Raw, error) {
 		return extractFindAndModify(raw)
 	case "update":
 		return extractUpdate(raw)
+	case "insert":
+		return extractInsert(raw)
 	default:
 		return raw, nil
 	}
@@ -407,6 +409,23 @@ func extractUpdate(statement bson.Raw) (bson.Raw, error) {
 		}
 	}
 	return nil, nil
+}
+
+func extractInsert(statement bson.Raw) (bson.Raw, error) {
+	elems, err := statement.Elements()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting elements for insert statement")
+	}
+
+	insertFields := []string{"ordered", "documents"}
+	var insertDoc bson.D
+	for _, elem := range elems {
+		if utility.StringSliceContains(insertFields, elem.Key()) {
+			insertDoc = append(insertDoc, bson.E{Key: elem.Key(), Value: elem.Value()})
+		}
+	}
+
+	return bson.Marshal(insertDoc)
 }
 
 func stripDocument(doc bson.Raw) (bson.Raw, error) {

--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -24,7 +24,6 @@ import (
 	"sync"
 
 	"github.com/evergreen-ci/utility"
-	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
@@ -144,14 +143,10 @@ func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 		if stmt := m.cfg.CommandTransformerFunc(evt.Command); stmt != "" {
 			if formattedStmt, err := extractStatement(evt.CommandName, stmt, false); err == nil && formattedStmt != "" {
 				attrs = append(attrs, semconv.DBStatement(formattedStmt))
-			} else {
-				grip.Error(errors.Wrap(err, "getting formatted statement"))
 			}
 
 			if strippedStatement, err := extractStatement(evt.CommandName, stmt, true); err == nil && strippedStatement != "" {
 				attrs = append(attrs, attribute.String(strippedStatementAttribute, strippedStatement))
-			} else {
-				grip.Error(errors.Wrap(err, "getting stripped statement"))
 			}
 		}
 	}

--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -375,7 +375,7 @@ func extractFindAndModify(statement bson.Raw) (bson.Raw, error) {
 		return nil, errors.Wrap(err, "getting elements for findAndModify statement")
 	}
 
-	findFields := []string{"query", "update"}
+	findFields := []string{"query", "update", "upsert"}
 	var findDoc bson.D
 	for _, elem := range elems {
 		if utility.StringSliceContains(findFields, elem.Key()) {
@@ -483,10 +483,14 @@ func compactArray(arr bson.A) bson.A {
 		if elemVal.Type != bson.TypeString {
 			return arr
 		}
-		if !types[elemVal.StringValue()] {
+		valString, ok := elemVal.StringValueOK()
+		if !ok {
+			return arr
+		}
+		if !types[valString] {
 			compactedArray = append(compactedArray, elem)
 		}
-		types[elemVal.StringValue()] = true
+		types[valString] = true
 	}
 
 	return compactedArray

--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -200,6 +200,9 @@ func (m *monitor) getSpan(evt *event.CommandFinishedEvent) (trace.Span, bool) {
 func (m *monitor) dbStatementAttributes(evt *event.CommandStartedEvent) ([]attribute.KeyValue, error) {
 	var attributes []attribute.KeyValue
 	command := m.cfg.CommandTransformerFunc(evt.Command)
+	if command == nil {
+		return nil, nil
+	}
 
 	section, err := operationSection(evt.CommandName, command)
 	if err != nil {

--- a/apm/otel_monitor_test.go
+++ b/apm/otel_monitor_test.go
@@ -128,7 +128,7 @@ func TestStripDocument(t *testing.T) {
 	}
 }
 
-func TestExtractStatement(t *testing.T) {
+func TestFormatStatement(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		input       string
 		commandName string
@@ -554,7 +554,10 @@ func TestExtractStatement(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			val, err := extractStatement(testCase.commandName, testCase.input, testCase.stripped)
+			section, err := extractStatement(testCase.commandName, testCase.input)
+			assert.NoError(t, err)
+
+			val, err := formatStatement(section, testCase.stripped)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expected, val)
 		})

--- a/apm/otel_monitor_test.go
+++ b/apm/otel_monitor_test.go
@@ -1,0 +1,562 @@
+package apm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestCompactArray(t *testing.T) {
+	_, type1, err := bson.MarshalValue("type 1")
+	require.NoError(t, err)
+	_, type2, err := bson.MarshalValue("type 2")
+	require.NoError(t, err)
+
+	for name, testCase := range map[string]struct {
+		input     bson.A
+		unchanged bool
+		expected  bson.A
+	}{
+		"emptyArray": {input: bson.A{}, unchanged: true},
+		"corruptValue": {
+			input: bson.A{
+				bson.RawValue{Type: bson.TypeString, Value: []byte("invalid bson")},
+				bson.RawValue{Type: bson.TypeString, Value: type1},
+			},
+			unchanged: true,
+		},
+		"arrayType": {
+			input: bson.A{
+				bson.RawValue{Type: bson.TypeString, Value: type1},
+				bson.RawValue{Type: bson.TypeArray},
+			},
+			unchanged: true,
+		},
+		"documentType": {
+			input: bson.A{
+				bson.RawValue{Type: bson.TypeString, Value: type1},
+				bson.RawValue{Type: bson.TypeEmbeddedDocument},
+			},
+			unchanged: true,
+		},
+		"multiplesOfEachType": {
+			input: bson.A{
+				bson.RawValue{Type: bson.TypeString, Value: type1},
+				bson.RawValue{Type: bson.TypeString, Value: type1},
+				bson.RawValue{Type: bson.TypeString, Value: type2},
+				bson.RawValue{Type: bson.TypeString, Value: type2},
+			},
+			expected: bson.A{
+				bson.RawValue{Type: bson.TypeString, Value: type1},
+				bson.RawValue{Type: bson.TypeString, Value: type2},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if testCase.unchanged {
+				assert.Equal(t, testCase.input, compactArray(testCase.input))
+			} else {
+				assert.Equal(t, testCase.expected, compactArray(testCase.input))
+			}
+		})
+	}
+}
+
+func TestStripDocument(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		input       bson.D
+		errExpected bool
+		expected    bson.D
+	}{
+		"simpleValues": {
+			input: bson.D{
+				{Key: "a_string", Value: "Why did the computer go broke? Because it used up all its cache!"},
+				{Key: "an_int", Value: 1},
+				{Key: "a_date", Value: time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)},
+			},
+			expected: bson.D{
+				{Key: "a_string", Value: "<string>"},
+				{Key: "an_int", Value: "<32-bit integer>"},
+				{Key: "a_date", Value: "<UTC datetime>"},
+			},
+		},
+		"nestedArray": {
+			input: bson.D{
+				{Key: "array", Value: []interface{}{"one", 2, "two", 3, time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}},
+			},
+			expected: bson.D{
+				{Key: "array", Value: []interface{}{"<string>", "<32-bit integer>", "<UTC datetime>"}},
+			},
+		},
+		"nestedSubdocument": {
+			input: bson.D{
+				{Key: "subdocument", Value: bson.M{"my_int": 1}},
+			},
+			expected: bson.D{
+				{Key: "subdocument", Value: bson.M{"my_int": "<32-bit integer>"}},
+			},
+		},
+		"nestedRecursively": {
+			input: bson.D{
+				{Key: "subdocument", Value: bson.M{"array": []interface{}{"one"}}},
+			},
+			expected: bson.D{
+				{Key: "subdocument", Value: bson.M{"array": []interface{}{"<string>"}}},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			input, err := bson.Marshal(testCase.input)
+			require.NoError(t, err)
+			expectedOutput, err := bson.MarshalExtJSON(testCase.expected, false, false)
+			require.NoError(t, err)
+
+			if testCase.errExpected {
+				_, err := stripDocument(input)
+				assert.Error(t, err)
+			} else {
+				val, err := stripDocument(input)
+				assert.NoError(t, err)
+				valString, err := bson.MarshalExtJSON(val, false, false)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedOutput, valString)
+			}
+		})
+	}
+}
+
+func TestExtractStatement(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		input       string
+		commandName string
+		stripped    bool
+		expected    string
+	}{
+		"aggregate": {
+			commandName: "aggregate",
+			input:       `{"aggregate":"evg.service.group","pipeline":[{"$match":{"group":"service.host.termination"}},{"$group":{"_id":1,"n":{"$sum":1}}}],"cursor":{},"readConcern":{"level":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731958801,"i":16}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"amboy"}`,
+			expected: `{
+  "pipeline": [
+    {
+      "$match": {
+        "group": "service.host.termination"
+      }
+    },
+    {
+      "$group": {
+        "_id": 1,
+        "n": {
+          "$sum": 1
+        }
+      }
+    }
+  ]
+}`,
+			stripped: false,
+		},
+		"aggregateStripped": {
+			commandName: "aggregate",
+			input:       `{"aggregate":"evg.service.group","pipeline":[{"$match":{"group":"service.host.termination"}},{"$group":{"_id":1,"n":{"$sum":1}}}],"cursor":{},"readConcern":{"level":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731958801,"i":16}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"amboy"}`,
+			expected: `{
+  "pipeline": [
+    {
+      "$match": {
+        "group": "<string>"
+      }
+    },
+    {
+      "$group": {
+        "_id": "<32-bit integer>",
+        "n": {
+          "$sum": "<32-bit integer>"
+        }
+      }
+    }
+  ]
+}`,
+			stripped: true,
+		},
+		"find": {
+			commandName: "find",
+			input:       `{"find":"admin","filter":{"_id":{"$in":["service_flags","tracer","pod_lifecycle","sleep_schedule","api","cedar","commit_queue","host_jasper","amboy_db","project_creation","spawnhost","github_check_run","slack","ui","hostinit","jira","notify","scheduler","amboy","providers","repotracker","auth","jira_notifications","task_limits","triggers","runtime_environments","splunk","global","buckets","container_pools","logger_config","newrelic"]}},"readConcern":{"level":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731961217,"i":520}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"$db":"mci"}`,
+			expected: `{
+  "filter": {
+    "_id": {
+      "$in": [
+        "service_flags",
+        "tracer",
+        "pod_lifecycle",
+        "sleep_schedule",
+        "api",
+        "cedar",
+        "commit_queue",
+        "host_jasper",
+        "amboy_db",
+        "project_creation",
+        "spawnhost",
+        "github_check_run",
+        "slack",
+        "ui",
+        "hostinit",
+        "jira",
+        "notify",
+        "scheduler",
+        "amboy",
+        "providers",
+        "repotracker",
+        "auth",
+        "jira_notifications",
+        "task_limits",
+        "triggers",
+        "runtime_environments",
+        "splunk",
+        "global",
+        "buckets",
+        "container_pools",
+        "logger_config",
+        "newrelic"
+      ]
+    }
+  }
+}`,
+		},
+		"findStripped": {
+			commandName: "find",
+			input:       `{"find":"admin","filter":{"_id":{"$in":["service_flags","tracer","pod_lifecycle","sleep_schedule","api","cedar","commit_queue","host_jasper","amboy_db","project_creation","spawnhost","github_check_run","slack","ui","hostinit","jira","notify","scheduler","amboy","providers","repotracker","auth","jira_notifications","task_limits","triggers","runtime_environments","splunk","global","buckets","container_pools","logger_config","newrelic"]}},"readConcern":{"level":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731961217,"i":520}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"$db":"mci"}`,
+			expected: `{
+  "filter": {
+    "_id": {
+      "$in": [
+        "<string>"
+      ]
+    }
+  }
+}`,
+			stripped: true,
+		},
+		"update": {
+			commandName: "update",
+			input:       `{"update":"tasks","ordered":true,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731958835,"i":578}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299994,"$db":"mci","updates":[{"q":{"activated_time":{"$lte":{"$date":"2024-11-11T19:40:35.484Z"}},"activated":true,"status":"undispatched","priority":{"$gt":-1},"$and":[{"$or":[{"execution_platform":{"$exists":false}},{"execution_platform":"host"}]},{"$or":[{"unattainable_dependency":false},{"override_dependencies":true}]}],"distro":{"$in":["ubuntu1804-small","ubuntu1804","ubuntu1804-test"]}},"u":{"$set":{"priority":-1,"activated":false}},"multi":true,"hint":{"distro":1,"status":1,"activated":1,"priority":1,"override_dependencies":1,"unattainable_dependency":1}}]}`,
+			expected: `{
+  "q": {
+    "activated_time": {
+      "$lte": {
+        "$date": "2024-11-11T19:40:35.484Z"
+      }
+    },
+    "activated": true,
+    "status": "undispatched",
+    "priority": {
+      "$gt": -1
+    },
+    "$and": [
+      {
+        "$or": [
+          {
+            "execution_platform": {
+              "$exists": false
+            }
+          },
+          {
+            "execution_platform": "host"
+          }
+        ]
+      },
+      {
+        "$or": [
+          {
+            "unattainable_dependency": false
+          },
+          {
+            "override_dependencies": true
+          }
+        ]
+      }
+    ],
+    "distro": {
+      "$in": [
+        "ubuntu1804-small",
+        "ubuntu1804",
+        "ubuntu1804-test"
+      ]
+    }
+  },
+  "u": {
+    "$set": {
+      "priority": -1,
+      "activated": false
+    }
+  },
+  "multi": true,
+  "hint": {
+    "distro": 1,
+    "status": 1,
+    "activated": 1,
+    "priority": 1,
+    "override_dependencies": 1,
+    "unattainable_dependency": 1
+  }
+}`,
+		},
+		"updateStripped": {
+			commandName: "update",
+			input:       `{"update":"tasks","ordered":true,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731958835,"i":578}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299994,"$db":"mci","updates":[{"q":{"activated_time":{"$lte":{"$date":"2024-11-11T19:40:35.484Z"}},"activated":true,"status":"undispatched","priority":{"$gt":-1},"$and":[{"$or":[{"execution_platform":{"$exists":false}},{"execution_platform":"host"}]},{"$or":[{"unattainable_dependency":false},{"override_dependencies":true}]}],"distro":{"$in":["ubuntu1804-small","ubuntu1804","ubuntu1804-test"]}},"u":{"$set":{"priority":-1,"activated":false}},"multi":true,"hint":{"distro":1,"status":1,"activated":1,"priority":1,"override_dependencies":1,"unattainable_dependency":1}}]}`,
+			expected: `{
+  "q": {
+    "activated_time": {
+      "$lte": "<UTC datetime>"
+    },
+    "activated": "<boolean>",
+    "status": "<string>",
+    "priority": {
+      "$gt": "<32-bit integer>"
+    },
+    "$and": [
+      {
+        "$or": [
+          {
+            "execution_platform": {
+              "$exists": "<boolean>"
+            }
+          },
+          {
+            "execution_platform": "<string>"
+          }
+        ]
+      },
+      {
+        "$or": [
+          {
+            "unattainable_dependency": "<boolean>"
+          },
+          {
+            "override_dependencies": "<boolean>"
+          }
+        ]
+      }
+    ],
+    "distro": {
+      "$in": [
+        "<string>"
+      ]
+    }
+  },
+  "u": {
+    "$set": {
+      "priority": "<32-bit integer>",
+      "activated": "<boolean>"
+    }
+  },
+  "multi": "<boolean>",
+  "hint": {
+    "distro": "<32-bit integer>",
+    "status": "<32-bit integer>",
+    "activated": "<32-bit integer>",
+    "priority": "<32-bit integer>",
+    "override_dependencies": "<32-bit integer>",
+    "unattainable_dependency": "<32-bit integer>"
+  }
+}`,
+			stripped: true,
+		},
+		"delete": {
+			commandName: "delete",
+			input:       `{"delete":"data_cache","ordered":true,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"txnNumber":361,"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731961014,"i":905}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"mci","deletes":[{"q":{"_id":"https://api.github.com/repos/evergreen-ci/evergreen/commits/86445d84a490b1df45184c48160c66f4549e879a"},"limit":1}]}`,
+			expected: `{
+  "q": {
+    "_id": "https://api.github.com/repos/evergreen-ci/evergreen/commits/86445d84a490b1df45184c48160c66f4549e879a"
+  },
+  "limit": 1
+}`,
+		},
+		"deleteStripped": {
+			commandName: "delete",
+			input:       `{"delete":"data_cache","ordered":true,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"txnNumber":361,"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731961014,"i":905}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"mci","deletes":[{"q":{"_id":"https://api.github.com/repos/evergreen-ci/evergreen/commits/86445d84a490b1df45184c48160c66f4549e879a"},"limit":1}]}`,
+			expected: `{
+  "q": {
+    "_id": "<string>"
+  },
+  "limit": "<32-bit integer>"
+}`,
+			stripped: true,
+		},
+		"findAndModify": {
+			commandName: "findAndModify",
+			input:       `{"findAndModify":"hosts","new":true,"query":{"_id":"i-012345678901"},"update":{"$inc":{"total_idle_time":103516332212}},"upsert":false,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"txnNumber":7795,"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731960233,"i":1022}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"mci"}`,
+			expected: `{
+  "query": {
+    "_id": "i-012345678901"
+  },
+  "update": {
+    "$inc": {
+      "total_idle_time": 103516332212
+    }
+  },
+  "upsert": false
+}`,
+		},
+		"findAndModifyStripped": {
+			commandName: "findAndModify",
+			input:       `{"findAndModify":"hosts","new":true,"query":{"_id":"i-012345678901"},"update":{"$inc":{"total_idle_time":103516332212}},"upsert":false,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"txnNumber":7795,"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731960233,"i":1022}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"mci"}`,
+			expected: `{
+  "query": {
+    "_id": "<string>"
+  },
+  "update": {
+    "$inc": {
+      "total_idle_time": "<64-bit integer>"
+    }
+  },
+  "upsert": "<boolean>"
+}`,
+			stripped: true,
+		},
+		"insert": {
+			commandName: "insert",
+			input:       `{"insert":"evg.service.group","ordered":false,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"txnNumber":1192,"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731959774,"i":1}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"amboy","documents":[{"_id":"service.generate.tasks.version.12345.generate-tasks-example_task_id","type":"generate-tasks","group":"service.generate.tasks.version.12345","version":0,"priority":0,"status":{"owner":"","completed":false,"in_prog":false,"mod_ts":{"$date":{"$numberLong":"-62135596800000"}},"mod_count":0,"err_count":0},"scopes":["generate-tasks.example_task_id"],"enqueue_scopes":["generate-tasks.example_task_id"],"retry_info":{"retryable":false,"needs_retry":false,"current_attempt":0},"time_info":{"created":{"$date":"2024-11-18T19:56:14.733Z"}},"job":{"job_base":{"name":"generate-tasks-example_task_id","job_type":{"name":"generate-tasks","version":0},"required_scopes":["generate-tasks.12345","generate-tasks.example_task_id"]},"task_id":"example_task_id"},"dependency":{"type":"always","version":0,"edges":[],"dependency":{"type":{"name":"always","version":0},"jobedges":{"edges":[]}}}}]}`,
+			expected: `{
+  "ordered": false,
+  "documents": [
+    {
+      "_id": "service.generate.tasks.version.12345.generate-tasks-example_task_id",
+      "type": "generate-tasks",
+      "group": "service.generate.tasks.version.12345",
+      "version": 0,
+      "priority": 0,
+      "status": {
+        "owner": "",
+        "completed": false,
+        "in_prog": false,
+        "mod_ts": {
+          "$date": {
+            "$numberLong": "-62135596800000"
+          }
+        },
+        "mod_count": 0,
+        "err_count": 0
+      },
+      "scopes": [
+        "generate-tasks.example_task_id"
+      ],
+      "enqueue_scopes": [
+        "generate-tasks.example_task_id"
+      ],
+      "retry_info": {
+        "retryable": false,
+        "needs_retry": false,
+        "current_attempt": 0
+      },
+      "time_info": {
+        "created": {
+          "$date": "2024-11-18T19:56:14.733Z"
+        }
+      },
+      "job": {
+        "job_base": {
+          "name": "generate-tasks-example_task_id",
+          "job_type": {
+            "name": "generate-tasks",
+            "version": 0
+          },
+          "required_scopes": [
+            "generate-tasks.12345",
+            "generate-tasks.example_task_id"
+          ]
+        },
+        "task_id": "example_task_id"
+      },
+      "dependency": {
+        "type": "always",
+        "version": 0,
+        "edges": [],
+        "dependency": {
+          "type": {
+            "name": "always",
+            "version": 0
+          },
+          "jobedges": {
+            "edges": []
+          }
+        }
+      }
+    }
+  ]
+}`,
+		},
+		"insertStripped": {
+			commandName: "insert",
+			input:       `{"insert":"evg.service.group","ordered":false,"writeConcern":{"w":"majority"},"lsid":{"id":{"$binary":{"base64":"aggafjahdfLSJKDF3as5Fg==","subType":"04"}}},"txnNumber":1192,"$clusterTime":{"clusterTime":{"$timestamp":{"t":1731959774,"i":1}},"signature":{"hash":{"$binary":{"base64":"asdksdh2afksfas+Fas/djasdEo=","subType":"00"}},"keyId":1234567890987654321}},"maxTimeMS":299999,"$db":"amboy","documents":[{"_id":"service.generate.tasks.version.12345.generate-tasks-example_task_id","type":"generate-tasks","group":"service.generate.tasks.version.12345","version":0,"priority":0,"status":{"owner":"","completed":false,"in_prog":false,"mod_ts":{"$date":{"$numberLong":"-62135596800000"}},"mod_count":0,"err_count":0},"scopes":["generate-tasks.example_task_id"],"enqueue_scopes":["generate-tasks.example_task_id"],"retry_info":{"retryable":false,"needs_retry":false,"current_attempt":0},"time_info":{"created":{"$date":"2024-11-18T19:56:14.733Z"}},"job":{"job_base":{"name":"generate-tasks-example_task_id","job_type":{"name":"generate-tasks","version":0},"required_scopes":["generate-tasks.12345","generate-tasks.example_task_id"]},"task_id":"example_task_id"},"dependency":{"type":"always","version":0,"edges":[],"dependency":{"type":{"name":"always","version":0},"jobedges":{"edges":[]}}}}]}`,
+			expected: `{
+  "ordered": "<boolean>",
+  "documents": [
+    {
+      "_id": "<string>",
+      "type": "<string>",
+      "group": "<string>",
+      "version": "<32-bit integer>",
+      "priority": "<32-bit integer>",
+      "status": {
+        "owner": "<string>",
+        "completed": "<boolean>",
+        "in_prog": "<boolean>",
+        "mod_ts": "<UTC datetime>",
+        "mod_count": "<32-bit integer>",
+        "err_count": "<32-bit integer>"
+      },
+      "scopes": [
+        "<string>"
+      ],
+      "enqueue_scopes": [
+        "<string>"
+      ],
+      "retry_info": {
+        "retryable": "<boolean>",
+        "needs_retry": "<boolean>",
+        "current_attempt": "<32-bit integer>"
+      },
+      "time_info": {
+        "created": "<UTC datetime>"
+      },
+      "job": {
+        "job_base": {
+          "name": "<string>",
+          "job_type": {
+            "name": "<string>",
+            "version": "<32-bit integer>"
+          },
+          "required_scopes": [
+            "<string>"
+          ]
+        },
+        "task_id": "<string>"
+      },
+      "dependency": {
+        "type": "<string>",
+        "version": "<32-bit integer>",
+        "edges": [],
+        "dependency": {
+          "type": {
+            "name": "<string>",
+            "version": "<32-bit integer>"
+          },
+          "jobedges": {
+            "edges": []
+          }
+        }
+      }
+    }
+  ]
+}`,
+			stripped: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			val, err := extractStatement(testCase.commandName, testCase.input, testCase.stripped)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, val)
+		})
+	}
+}

--- a/apm/otel_monitor_test.go
+++ b/apm/otel_monitor_test.go
@@ -554,7 +554,10 @@ func TestFormatStatement(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			section, err := extractStatement(testCase.commandName, testCase.input)
+			var raw bson.Raw
+			require.NoError(t, bson.UnmarshalExtJSON([]byte(testCase.input), false, &raw))
+
+			section, err := operationSection(testCase.commandName, raw)
 			assert.NoError(t, err)
 
 			val, err := formatStatement(section, testCase.stripped)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/evergreen-ci/birch v0.0.0-20220401151432-c792c3d8e0eb
 	github.com/evergreen-ci/tarjan v0.0.0-20170824211642-fcd3f3321826
+	github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d
 	github.com/mongodb/amboy v0.0.0-20231019011216-6a7b0ad303b3
 	github.com/mongodb/grip v0.0.0-20231010153552-fd9e260891f5
 	github.com/pkg/errors v0.9.1
@@ -29,7 +30,6 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dghubble/oauth1 v0.7.2 // indirect
-	github.com/evergreen-ci/utility v0.0.0-20231017180358-3a3a0617644d // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fuyufjh/splunk-hec-go v0.4.0 // indirect


### PR DESCRIPTION
[DEVPROD-12678](https://jira.mongodb.org/browse/DEVPROD-12678)

The database has a concept of [query shape](https://www.mongodb.com/docs/manual/core/query-shapes/) where queries are grouped so they can use the same query plan. We can't get the actual shape off the server, but we can reduce a query to something shape-like so we can group on it. For example, this enables [this query](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/3krthmLjpCK) (shows the count of each query), [this query](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/8n44bE2N86e) (shows which queries are pulling a lot of data from the database), etc.

We might want to use this to discover [which versions query is responsible for 54GB of data per minute](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/taLtkeBDCR4?hideCompare).

Also remove the extra driver cruft from the db.statement attribute for operations we care about.

Also pretty print the `db.statement` attribute.