### PR TITLE
DEVPROD-16010 add stack trace to db otel spans

### DIFF
--- a/apm/otel_monitor.go
+++ b/apm/otel_monitor.go
@@ -43,10 +43,12 @@ const (
 	responseBytesAttribute     = "db.response_bytes"
 	strippedStatementAttribute = "db.statement.stripped"
 
-	// stackSkip is the number of frames to skip to start the stack at the function that called the driver.
-	stackSkip = 8
+	// stackSkip is the number of frames to skip to start the stack at the driver.
+	stackSkip = 4
 	// stackSize is the maximum number of frames to capture.
 	stackSize = 50
+	// driverFunctionPrefix is the prefix of [runtime.Frame.Function] for driver frames.
+	driverFunctionPrefix = "go.mongodb.org/mongo-driver"
 )
 
 // config is used to configure the mongo tracer.
@@ -534,6 +536,10 @@ func getStackTrace(stackSkip int) string {
 	stack := ""
 	for {
 		frame, more := frames.Next()
+		// Skip frames internal to the driver.
+		if strings.HasPrefix(frame.Function, driverFunctionPrefix) {
+			continue
+		}
 		stack += fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
 
 		if !more {

--- a/apm/otel_monitor_test.go
+++ b/apm/otel_monitor_test.go
@@ -566,3 +566,9 @@ func TestFormatStatement(t *testing.T) {
 		})
 	}
 }
+
+func TestGetStackTrace(t *testing.T) {
+	trace := getStackTrace(0)
+	assert.Contains(t, trace, "github.com/mongodb/anser/apm.getStackTrace")
+	assert.Contains(t, trace, "github.com/mongodb/anser/apm.TestGetStackTrace")
+}


### PR DESCRIPTION
[DEVPROD-16010](https://jira.mongodb.org/browse/DEVPROD-16010)

When I was trying to figure out which database calls where problematic it was difficult to trace a db span back to the code that made the call. And even if we know the function the call is being made from it could be just a specific execution path is problematic.

This PR adds the call stack as an attribute. [This](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/pWHDi1MSS4k/trace/GeTsvd9mPvN?fields[]=s_name&fields[]=s_serviceName&span=ddd0f59327bf8f5e) is an example (look for the `code.stacktrace` attribute).